### PR TITLE
Fixing the upload component to not clear files before uploading

### DIFF
--- a/src/app/azure-storage/components/input-file.component.ts
+++ b/src/app/azure-storage/components/input-file.component.ts
@@ -22,8 +22,8 @@ export class InputFileComponent {
   constructor(private blobState: BlobUploadsViewStateService) {}
 
   onSelected(files: FileList): void {
-    this.fileInput.nativeElement.value = '';
     this.blobState.uploadItems(files);
+    this.fileInput.nativeElement.value = '';
   }
 
   showFileDialog(): void {


### PR DESCRIPTION
I noticed that the upload component wasn't working as expected. The files were being cleared prior to upload.